### PR TITLE
👷‍♂️📦🏷️ [ION-285] workflow for publishing new releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            core.setFailed('you can only run the publish workflow from a release tag (vX.Y.Z)')
+            core.notice('you can only run the publish workflow from a release tag (vX.Y.Z)')
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -37,11 +37,11 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            core.setFailed('library version does not match the github tag')
+            core.notice('library version does not match the github tag')
       - name: Build release
         id: build-release
         run: poetry build
       - name: Publish version to PyPI
         id: publish-release
-        run: poetry publish -u __token__ -p ${{ secrets.PYPI_API_TOKEN }}
+        run: poetry publish -u __token__ -p ${{ secrets.PYPI_API_TOKEN }} --dry-run
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+on:
+  workflow_dispatch:
+jobs:
+  publish-release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure valid tag reference
+        if: ${{ github.ref_type != 'tag' }} || ${{ !startsWith(github.ref_name, 'v') }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.setFailed('you can only run the publish workflow from a release tag (vX.Y.Z)')
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+      - name: Set up python
+        uses: actions/setup-python@v4
+        with:
+          python-version-file: .python-version
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: "1.6.1"
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: true
+      - name: output library version
+        id: output-version
+        # prefix with v to match tag convention
+        run: poetry version -s | awk '{ print "version=v" $1 }' >> $GITHUB_OUTPUT
+      - name: check library version
+        if: ${{ steps.output-version.outputs.version }} != ${{ github.ref }}
+        id: check-version
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.setFailed('library version does not match the github tag')
+      - name: Build release
+        id: build-release
+        run: poetry build
+      - name: Publish version to PyPI
+        id: publish-release
+        run: poetry publish -u __token__ -p ${{ secrets.PYPI_API_TOKEN }}
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ionic-langchain"
-version = "0.1.2"
+version = "0.1.3"
 description = ""
 authors = ["Owen Sims <owen@ionicapi.com>"]
 readme = "README.md"


### PR DESCRIPTION
Right now the workflow is intended to

* build artifacts
* publish them to pypi

Currently this requires manually bumping poetry and creating a
git tag/release, but I added a couple of guardrails so that we ensure
we only publish when the poetry package version matches the github
release reference.

Eventually the workflow will be able to:

* bump the pyproject version itself
* create a tag based on the version
* cut a release on that tag